### PR TITLE
Update to preact 7. Fixes #4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "barracks": "^8.2.1",
     "hyperx": "^2.0.4",
     "nanoraf": "^2.1.1",
-    "preact": "^5.7.0",
+    "preact": "^7.1.0",
     "sheet-router": "4.0.0-0",
     "xtend": "^4.0.1",
     "yo-yo": "^1.2.2"


### PR DESCRIPTION
#4 seemed to be caused by preact <6 not handling nested children arrays properly. As of 6 children is now recursively flattened. Since 7.1.0 is the latest, it probably makes sense just to go all the way.