### PR TITLE
extend preact component prototype

### DIFF
--- a/component.js
+++ b/component.js
@@ -1,1 +1,3 @@
-module.exports = require('preact').Component
+function Component () {}
+Component.prototype = Object.create(require('preact').Component.prototype)
+module.exports = Component


### PR DESCRIPTION
In [rooch/component.js](https://github.com/yoshuawuyts/rooch/blob/master/component.js), rather than simply proxying preact component constructor like this:

```js
module.exports = require('preact').Component
```

instead, create a new Component constructor which inherits from preact's:

```js
function Component () {}
Component.prototype = Object.create(require('preact').Component.prototype)
module.exports = Component
```

---

Doing this allows us to extend a special rooch specific component in our app, which has access to emit, like this:

```js
app.use(function (state, emitter) {
  require('rooch/component').prototype.emit = function (eventName, data) {
    emitter.emit(eventName, data)
  }
})
```

Allowing state changes to be triggered directly within components:

```js
class btnComponent extends Component {
  constructor () { super() }

  render () {
    return html`
      <button onclick=${() => this.emit('eventName')}>Click</button>
    `
  }
}
```

While you can pass emit as a prop (and that might be good/better pattern), this change simply allows you to create this kind of *special* component constructor if you *want* to.